### PR TITLE
feat: temporarily disable benchmark

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,7 +18,7 @@ cc_binary(
     copts = copts,
     stamp = 1,
     deps = [
-        "//commands:benchmark",
+        # "//commands:benchmark",
         "//commands:codegen",
         "//commands:command",
         "//commands:config",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,13 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 http_archive(
-    name = "ecsact_si_wasm",
-    sha256 = "e208a94d4f4a9c09f32b8a9ea91a4f799492e11c7c852b0329b4a3595a45cee6",
-    strip_prefix = "ecsact_si_wasm-0.1.0",
-    urls = ["https://github.com/seaube/ecsact_si_wasm/archive/refs/tags/0.1.0.tar.gz"],
-)
-
-http_archive(
     name = "hedron_compile_commands",
     sha256 = "ed5aea1dc87856aa2029cb6940a51511557c5cac3dbbcb05a4abd989862c36b4",
     strip_prefix = "bazel-compile-commands-extractor-e16062717d9b098c3c2ac95717d2b3e661c50608",
@@ -33,9 +26,7 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
     name = "llvm_toolchain",
-    cxx_standard = {"linux": "c++20"},
-    distribution = "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
-    llvm_version = "15.0.6",
+    llvm_version = "16.0.4",
 )
 
 load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")

--- a/commands/BUILD.bazel
+++ b/commands/BUILD.bazel
@@ -9,24 +9,24 @@ cc_library(
     copts = copts,
 )
 
-cc_library(
-    name = "benchmark",
-    srcs = ["benchmark.cc"],
-    hdrs = ["benchmark.hh"],
-    copts = copts,
-    deps = [
-        ":command",
-        "//executable_path",
-        "@magic_enum",
-        "@docopt.cpp//:docopt",
-        "@boost.dll",
-        "@ecsact_runtime//:core",
-        "@ecsact_runtime//:async",
-        "@ecsact_runtime//:serialize",
-        "@ecsact_si_wasm//:ecsactsi_wasm",
-        "@nlohmann_json//:json",
-    ],
-)
+# cc_library(
+#     name = "benchmark",
+#     srcs = ["benchmark.cc"],
+#     hdrs = ["benchmark.hh"],
+#     copts = copts,
+#     deps = [
+#         ":command",
+#         "//executable_path",
+#         "@magic_enum",
+#         "@docopt.cpp//:docopt",
+#         "@boost.dll",
+#         "@ecsact_runtime//:core",
+#         "@ecsact_runtime//:async",
+#         "@ecsact_runtime//:serialize",
+#         "@ecsact_si_wasm",
+#         "@nlohmann_json//:json",
+#     ],
+# )
 
 cc_library(
     name = "codegen",

--- a/ecsact_cli.cc
+++ b/ecsact_cli.cc
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include "bazel_stamp_header.hh"
 
-#include "./commands/benchmark.hh"
+// #include "./commands/benchmark.hh"
 #include "./commands/codegen.hh"
 #include "./commands/command.hh"
 #include "./commands/config.hh"
@@ -72,7 +72,7 @@ int main(int argc, char* argv[]) {
 	using ecsact::cli::detail::command_fn_t;
 
 	const std::unordered_map<std::string, command_fn_t> commands{
-		{"benchmark", &ecsact::cli::detail::benchmark_command},
+		// {"benchmark", &ecsact::cli::detail::benchmark_command},
 		{"codegen", &ecsact::cli::detail::codegen_command},
 		{"config", &ecsact::cli::detail::config_command},
 	};


### PR DESCRIPTION
while waiting for https://github.com/ecsact-dev/ecsact_si_wasm/pull/37 to merge we are disabling the benchmark subcommand to not slow down the bzlmodification of all ecsact modules