### PR TITLE
fix: add missing SDK includes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 2,
 )
 
-bazel_dep(name = "rules_cc", version = "0.0.8")
+bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "nlohmann_json", version = "3.11.2")
 bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "rules_pkg", version = "0.9.1")

--- a/ecsact/cli/commands/BUILD.bazel
+++ b/ecsact/cli/commands/BUILD.bazel
@@ -35,7 +35,6 @@ cc_library(
     copts = copts,
     deps = [
         ":command",
-        "//ecsact/cli/detail/executable_path",
         "//ecsact/cli/commands/codegen:codegen",
         "@magic_enum",
         "@docopt.cpp//:docopt",
@@ -55,7 +54,7 @@ cc_library(
     copts = copts,
     deps = [
         ":command",
-        "//ecsact/cli/detail/executable_path",
+        "//ecsact/cli/detail:argv0",
         "@docopt.cpp//:docopt",
         "@nlohmann_json//:json",
     ],
@@ -72,7 +71,6 @@ cc_library(
         "//ecsact/cli:report_message",
         "//ecsact/cli/detail:json_report",
         "//ecsact/cli/detail:text_report",
-        "//ecsact/cli/detail/executable_path",
         "//ecsact/cli/commands/build/recipe:taste",
         "//ecsact/cli/commands/build/recipe:cook",
         "//ecsact/cli/commands/build:cc_compiler",

--- a/ecsact/cli/commands/build.cc
+++ b/ecsact/cli/commands/build.cc
@@ -12,6 +12,7 @@
 #include "ecsact/interpret/eval.hh"
 #include "ecsact/runtime/meta.hh"
 #include "ecsact/cli/report.hh"
+#include "ecsact/cli/detail/argv0.hh"
 #include "ecsact/cli/detail/json_report.hh"
 #include "ecsact/cli/detail/text_report.hh"
 #include "ecsact/cli/commands/build/recipe/taste.hh"
@@ -52,6 +53,7 @@ auto ecsact::cli::detail::build_command( //
 ) -> int {
 	auto args = docopt::docopt(USAGE, {argv + 1, argv + argc});
 	auto format = args["--format"].asString();
+	auto exec_path = canon_argv0(argv[0]);
 
 	if(format == "text") {
 		set_report_handler(text_report{});

--- a/ecsact/cli/commands/build/build_recipe.cc
+++ b/ecsact/cli/commands/build/build_recipe.cc
@@ -109,7 +109,9 @@ static auto parse_sources( //
 			} else if(path) {
 				auto src_path = fs::path{path.as<std::string>()};
 				auto outdir = std::optional<std::string>{};
-				auto relative_to_cwd = src["relative_to_cwd"].as<bool>();
+				auto relative_to_cwd = src["relative_to_cwd"] //
+					? src["relative_to_cwd"].as<bool>()
+					: false;
 				if(src["outdir"]) {
 					outdir = src["outdir"].as<std::string>();
 				}

--- a/ecsact/cli/commands/build/recipe/BUILD.bazel
+++ b/ecsact/cli/commands/build/recipe/BUILD.bazel
@@ -26,6 +26,7 @@ cc_library(
     }),
     deps = [
         "//ecsact/cli:report",
+        "//ecsact/cli/detail:argv0",
         "//ecsact/cli/commands/build:build_recipe",
         "//ecsact/cli/commands/build:cc_compiler_config",
         "//ecsact/cli/commands/codegen:codegen",

--- a/ecsact/cli/commands/codegen.cc
+++ b/ecsact/cli/commands/codegen.cc
@@ -15,7 +15,6 @@
 #include "ecsact/runtime/dylib.h"
 #include "ecsact/codegen/plugin.h"
 #include "ecsact/codegen/plugin_validate.hh"
-#include "ecsact/cli/detail/executable_path/executable_path.hh"
 #include "ecsact/cli/commands/codegen/codegen.hh"
 
 namespace fs = std::filesystem;

--- a/ecsact/cli/commands/config.cc
+++ b/ecsact/cli/commands/config.cc
@@ -6,7 +6,7 @@
 #include <string>
 #include "docopt.h"
 #include "nlohmann/json.hpp"
-#include "ecsact/cli/detail/executable_path/executable_path.hh"
+#include "ecsact/cli/detail/argv0.hh"
 
 namespace fs = std::filesystem;
 
@@ -46,19 +46,9 @@ constexpr auto CANNOT_FIND_PLUGIN_DIR = R"(
 
 int ecsact::cli::detail::config_command(int argc, char* argv[]) {
 	using namespace std::string_literals;
-	using executable_path::executable_path;
 
 	auto args = docopt::docopt(USAGE, {argv + 1, argv + argc});
-	auto exec_path = executable_path();
-	if(exec_path.empty()) {
-		exec_path = fs::path{argv[0]};
-		std::error_code ec;
-		exec_path = fs::canonical(exec_path, ec);
-		if(ec) {
-			exec_path = fs::weakly_canonical(fs::path{argv[0]});
-		}
-	}
-
+	auto exec_path = canon_argv0(argv[0]);
 	auto install_prefix = exec_path.parent_path().parent_path();
 	auto plugin_dir = install_prefix / "share" / "ecsact" / "plugins";
 	auto output = "{}"_json;

--- a/ecsact/cli/detail/BUILD.bazel
+++ b/ecsact/cli/detail/BUILD.bazel
@@ -4,6 +4,16 @@ load("//bazel:copts.bzl", "copts")
 package(default_visibility = ["//:__subpackages__"])
 
 cc_library(
+    name = "argv0",
+    srcs = ["argv0.cc"],
+    hdrs = ["argv0.hh"],
+    copts = copts,
+    deps = [
+        "//ecsact/cli/detail/executable_path",
+    ],
+)
+
+cc_library(
     name = "json_report",
     copts = copts,
     hdrs = ["json_report.hh"],

--- a/ecsact/cli/detail/argv0.cc
+++ b/ecsact/cli/detail/argv0.cc
@@ -1,0 +1,22 @@
+#include "ecsact/cli/detail/argv0.hh"
+
+#include <filesystem>
+#include "ecsact/cli/detail/executable_path/executable_path.hh"
+
+namespace fs = std::filesystem;
+
+auto ecsact::cli::detail::canon_argv0( //
+	const char* argv0
+) -> std::filesystem::path {
+	auto exec_path = executable_path::executable_path();
+	if(exec_path.empty()) {
+		exec_path = fs::path{argv0};
+		auto ec = std::error_code{};
+		exec_path = fs::canonical(exec_path, ec);
+		if(ec) {
+			exec_path = fs::weakly_canonical(fs::path{argv0});
+		}
+	}
+
+	return exec_path;
+}

--- a/ecsact/cli/detail/argv0.hh
+++ b/ecsact/cli/detail/argv0.hh
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <filesystem>
+
+namespace ecsact::cli::detail {
+  auto canon_argv0(const char* argv0) -> std::filesystem::path;
+}

--- a/ecsact/cli/detail/argv0.hh
+++ b/ecsact/cli/detail/argv0.hh
@@ -3,5 +3,5 @@
 #include <filesystem>
 
 namespace ecsact::cli::detail {
-  auto canon_argv0(const char* argv0) -> std::filesystem::path;
+auto canon_argv0(const char* argv0) -> std::filesystem::path;
 }


### PR DESCRIPTION
when using the SDK the include directory wasn't being passed to the compiler
