### PR TITLE
feat: always build with ECSACT_BUILD define

### DIFF
--- a/ecsact/cli/commands/build/recipe/cook.cc
+++ b/ecsact/cli/commands/build/recipe/cook.cc
@@ -393,6 +393,8 @@ auto clang_gcc_compile(compile_options options) -> int {
 		return 1;
 	}
 
+	compile_proc_args.push_back("-DECSACT_BUILD");
+
 	for(auto def : generated_defines) {
 		compile_proc_args.push_back(std::format("-D{}", def));
 	}
@@ -504,6 +506,7 @@ auto cl_compile(compile_options options) -> int {
 	cl_args.push_back("/nologo");
 	cl_args.push_back("/std:c++20");
 	cl_args.push_back("/diagnostics:column");
+	cl_args.push_back("/DECSACT_BUILD");
 
 	// TODO(zaucy): Add debug mode
 	// if(options.debug) {

--- a/test/build_recipe/ecsact_build_test.cc
+++ b/test/build_recipe/ecsact_build_test.cc
@@ -3,6 +3,11 @@
 
 #include "local_dep.hh"
 
+// This define is _always_ defined when using the Ecsact CLI build command
+#ifndef ECSACT_BUILD
+#	error "This test should only have been built through 'ecsact build'"
+#endif
+
 ecsact_registry_id ecsact_create_registry( //
 	const char*
 ) {

--- a/test/build_recipe/ecsact_build_test_merge.cc
+++ b/test/build_recipe/ecsact_build_test_merge.cc
@@ -1,5 +1,10 @@
 #include "ecsact/runtime/dynamic.h"
 
+// This define is _always_ defined when using the Ecsact CLI build command
+#ifndef ECSACT_BUILD
+#	error "This test should only have been built through 'ecsact build'"
+#endif
+
 void ecsact_system_execution_context_get(struct ecsact_system_execution_context*, ecsact_component_like_id, void*) {
 }
 


### PR DESCRIPTION
When building with 'ecsact build' there will always be a C/C++ define called `ECSACT_BUILD`
